### PR TITLE
Replace Matlabpool with Parpool

### DIFF
--- a/gradvecglmalphap.m
+++ b/gradvecglmalphap.m
@@ -131,7 +131,7 @@ else
         V=repmat(0,1,ldim);
         disp('Calculating in parallel mode')
         try
-            matlabpool open
+            parpool
         end
         parfor mm=1:maxL+1
             m=mm-1;

--- a/gradvecglmalphaptoJp.m
+++ b/gradvecglmalphaptoJp.m
@@ -46,7 +46,7 @@ H=out2on(H(:,1:J),L);
 %hh=waitbar(0,sprintf('Rotating the first %d Slepian functions',J));
 disp('Calculating rotations in parallel mode')
 try
-matlabpool open
+    parpool
 end
 parfor j=1:J  
     lmcosip=lmcosi;  

--- a/inoutgradvecglmalpha.m
+++ b/inoutgradvecglmalpha.m
@@ -58,9 +58,9 @@ if exist(fname,'file')==2
 else       
     % If possible, do parallel
     try 
-        matlabpool open
+        parpool
     %catch
-    %    disp('Matlabpool already open')
+    %    disp('Parpool already open')
     end
 
     % Find row indices into G belonging to the orders

--- a/kernelbp.m
+++ b/kernelbp.m
@@ -366,7 +366,7 @@ else
             D(lm1dex,:)=temprowD;
         end %parfor
             
-	      % Close the parpool
+        % Close the parpool
         delete(gcp('nocreate'));
       
         % Symmetrize the Kernel

--- a/kernelbp.m
+++ b/kernelbp.m
@@ -193,7 +193,7 @@ else
     if ~isstr(method) % GL with 'method' Gauss points       
         % See if we can run this calculation in parallel, and set a flag
         try
-            matlabpool open       
+            parpool      
         end
         
         intv=cos([thS thN]);
@@ -366,10 +366,8 @@ else
             D(lm1dex,:)=temprowD;
         end %parfor
             
-	% Close the matlabpool
-	try
-          matlabpool close
-	end
+	% Close the parpool
+  delete(gcp('nocreate'));
       
         % Symmetrize the Kernel
         B = B + B' - diag(diag(B));

--- a/kernelbp.m
+++ b/kernelbp.m
@@ -366,8 +366,8 @@ else
             D(lm1dex,:)=temprowD;
         end %parfor
             
-	% Close the parpool
-  delete(gcp('nocreate'));
+	  % Close the parpool
+    delete(gcp('nocreate'));
       
         % Symmetrize the Kernel
         B = B + B' - diag(diag(B));

--- a/kernelbp.m
+++ b/kernelbp.m
@@ -367,7 +367,7 @@ else
         end %parfor
             
         % Close the parpool
-        delete(gcp('nocreate'));
+        delete(gcp('nocreate'))
       
         % Symmetrize the Kernel
         B = B + B' - diag(diag(B));

--- a/kernelbp.m
+++ b/kernelbp.m
@@ -366,8 +366,8 @@ else
             D(lm1dex,:)=temprowD;
         end %parfor
             
-	  % Close the parpool
-    delete(gcp('nocreate'));
+	      % Close the parpool
+        delete(gcp('nocreate'));
       
         % Symmetrize the Kernel
         B = B + B' - diag(diag(B));

--- a/outgradvecglmalphatoJ.m
+++ b/outgradvecglmalphatoJ.m
@@ -47,7 +47,7 @@ else
     %H=out2on(H(:,1:J),L);
     disp('Calculating rotations in parallel mode')
     try
-        matlabpool open
+        parpool
     end
     parfor j=1:J   
     %for j=1:J 

--- a/torvecglmalpha.m
+++ b/torvecglmalpha.m
@@ -69,7 +69,7 @@ if exist(fname,'file')==2
     disp(sprintf('Loading %s',fname))
 else  
     try 
-        matlabpool open
+        parpool
     end
   
     % For GEOGRAPHICAL REGIONS or XY REGIONS

--- a/torvecglmalphatoJ.m
+++ b/torvecglmalphatoJ.m
@@ -47,7 +47,7 @@ else
       %H=out2on(H(:,1:J),L);
     disp('Calculating rotations in parallel mode')
     try
-        matlabpool open
+        parpool
     end
     parfor j=1:J   
     %for j=1:J 


### PR DESCRIPTION
Matlab has deprecated Matlabpool and replaced it with Parpool.  This PR updates existing code in Slepian_Golf accordingly, while preserving the style therein.

It's worth mentioning that there are a number of problems with the formatting / indentation of `kernelbp.m`, and I think there may even be some missing `end` lines in parts of the logic of that file.  I do not attempt to fix those problems in this PR, but they may be worth addressing in the future if that code is in active use / development.